### PR TITLE
fix: remove unused proofGenerationSeconds histogram

### DIFF
--- a/solver/src/metrics.ts
+++ b/solver/src/metrics.ts
@@ -55,14 +55,6 @@ export const transferDurationSeconds = new Histogram({
   registers: [registry],
 });
 
-export const proofGenerationSeconds = new Histogram({
-  name: "freeflo_proof_generation_seconds",
-  help: "Duration of zkTLS proof generation in seconds",
-  labelNames: ["provider"] as const,
-  buckets: [1, 5, 10, 30, 60, 120, 300],
-  registers: [registry],
-});
-
 export const attestationDurationSeconds = new Histogram({
   name: "freeflo_attestation_duration_seconds",
   help: "Duration of attestation requests in seconds",


### PR DESCRIPTION
## Summary

Addresses Tech Lead feedback on PR #9 by removing unused code:

- Removes the `proofGenerationSeconds` histogram from `solver/src/metrics.ts` that was defined but never used anywhere in the codebase

## Context

The Tech Lead review on PR #9 noted:
> "Also contains unused proofGenerationSeconds histogram"

This histogram was added speculatively for future zkTLS proof timing but was never instrumented. Removing it reduces bloat and improves code quality.

## Changes

- `solver/src/metrics.ts`: Removed unused `proofGenerationSeconds` histogram (8 lines deleted)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (8 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)