### PR TITLE
feat: Add spinner and loading states to intent creation flow

### DIFF
--- a/frontend/components/OffRampForm.tsx
+++ b/frontend/components/OffRampForm.tsx
@@ -735,10 +735,15 @@ export function OffRampV2() {
 
         <button
           onClick={handleCommit}
-          disabled={isApproving || isApproveConfirming || isSelectingQuote || isSelectConfirming || !!receivingInfoError || !receivingInfo || !recipientName}
-          className="w-full py-4 rounded-xl bg-gradient-to-r from-emerald-500 to-teal-500 text-white font-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
+          disabled={isCreatingIntent || isCreateConfirming || isApproving || isApproveConfirming || isSelectingQuote || isSelectConfirming || !!receivingInfoError || !receivingInfo || !recipientName}
+          className="w-full py-4 rounded-xl bg-gradient-to-r from-emerald-500 to-teal-500 text-white font-semibold disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
         >
-          {isApproving || isApproveConfirming
+          {(isCreatingIntent || isCreateConfirming || isApproving || isApproveConfirming || isSelectingQuote || isSelectConfirming) && (
+            <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          )}
+          {isCreatingIntent || isCreateConfirming
+            ? "Creating Intent..."
+            : isApproving || isApproveConfirming
             ? "Approving USDC..."
             : isSelectingQuote || isSelectConfirming
             ? "Confirming..."


### PR DESCRIPTION
## Summary
- Adds animated spinner to the "Confirm & Send" button during blockchain transactions
- Disables button during intent creation (previously missing)
- Adds "Creating Intent..." status text for intent creation phase
- Uses Tailwind animate-spin for consistent styling with the rest of the UI

## Evidence
- Linked issue: https://github.com/MontaguSandwich/FreeFlo/issues/6
- File reference: `frontend/components/OffRampForm.tsx:736-751`
- The button previously only showed loading states for USDC approval and quote selection, but not for intent creation

## Dependencies
- Lockfile changes: NO
- Dependency changes: NONE

## Changes
- Added spinner (border-based with animate-spin) that appears during any transaction state
- Added `isCreatingIntent` and `isCreateConfirming` to button's disabled condition
- Added "Creating Intent..." text for intent creation phase
- Updated button className to use flex layout for proper spinner/text alignment

## Testing
- Verified build succeeds with `npm run build`
- No new TypeScript errors
- Spinner uses standard Tailwind animate-spin class already used elsewhere in the codebase

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)