### PR TITLE
fix: Improve error messages in attestation client

### DIFF
--- a/solver/src/attestation/errors.test.ts
+++ b/solver/src/attestation/errors.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  AttestationServiceError,
+  AttestationStage,
+  classifyAttestationError,
+  createConnectionError,
+} from "./errors.js";
+
+describe("AttestationServiceError", () => {
+  it("should create error with all required fields", () => {
+    const error = new AttestationServiceError({
+      stage: AttestationStage.VERIFICATION,
+      originalError: "Verification failed: Invalid signature",
+      suggestion: "Regenerate TLSNotary proof",
+      httpCode: 400,
+      intentHash: "0x123",
+    });
+
+    expect(error.message).toContain("VERIFICATION");
+    expect(error.message).toContain("Verification failed: Invalid signature");
+    expect(error.message).toContain("Regenerate TLSNotary proof");
+    expect(error.stage).toBe(AttestationStage.VERIFICATION);
+    expect(error.originalError).toBe("Verification failed: Invalid signature");
+    expect(error.suggestion).toBe("Regenerate TLSNotary proof");
+    expect(error.httpCode).toBe(400);
+    expect(error.intentHash).toBe("0x123");
+    expect(error.name).toBe("AttestationServiceError");
+  });
+
+  it("should produce structured log context", () => {
+    const error = new AttestationServiceError({
+      stage: AttestationStage.CONNECTION,
+      originalError: "ECONNREFUSED",
+      suggestion: "Start attestation service",
+      httpCode: undefined,
+      intentHash: "0xabc",
+    });
+
+    const context = error.toLogContext();
+    expect(context.errorType).toBe("AttestationServiceError");
+    expect(context.stage).toBe(AttestationStage.CONNECTION);
+    expect(context.originalError).toBe("ECONNREFUSED");
+    expect(context.suggestion).toBe("Start attestation service");
+    expect(context.intentHash).toBe("0xabc");
+  });
+});
+
+describe("classifyAttestationError", () => {
+  describe("connection errors", () => {
+    it("should classify ECONNREFUSED", () => {
+      const error = classifyAttestationError("ECONNREFUSED", undefined, "0x123");
+      expect(error.stage).toBe(AttestationStage.CONNECTION);
+      expect(error.suggestion).toContain("docker compose");
+    });
+
+    it("should classify timeout errors", () => {
+      const error = classifyAttestationError("Request timeout", undefined, "0x123");
+      expect(error.stage).toBe(AttestationStage.CONNECTION);
+      expect(error.suggestion).toContain("timed out");
+    });
+
+    it("should classify DNS errors", () => {
+      const error = classifyAttestationError("getaddrinfo ENOTFOUND localhost", undefined, "0x123");
+      expect(error.stage).toBe(AttestationStage.CONNECTION);
+      expect(error.suggestion).toContain("ATTESTATION_SERVICE_URL");
+    });
+  });
+
+  describe("proof submission errors", () => {
+    it("should classify invalid presentation", () => {
+      const error = classifyAttestationError("Invalid presentation: bad format", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.PROOF_SUBMISSION);
+      expect(error.suggestion).toContain("Regenerate");
+    });
+
+    it("should classify deserialization errors", () => {
+      const error = classifyAttestationError("Deserialization error: invalid JSON", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.PROOF_SUBMISSION);
+      expect(error.suggestion).toContain("corrupted");
+    });
+
+    it("should classify missing field errors", () => {
+      const error = classifyAttestationError("Missing required field: amount", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.PROOF_SUBMISSION);
+      expect(error.suggestion).toContain("required data");
+    });
+  });
+
+  describe("verification errors", () => {
+    it("should classify verification failed", () => {
+      const error = classifyAttestationError("Verification failed: signature mismatch", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.VERIFICATION);
+      expect(error.suggestion).toContain("expired or tampered");
+    });
+
+    it("should classify unexpected server", () => {
+      const error = classifyAttestationError(
+        "Unexpected server: expected api.bank.com, got other.com",
+        400,
+        "0x123"
+      );
+      expect(error.stage).toBe(AttestationStage.VERIFICATION);
+      expect(error.suggestion).toContain("ALLOWED_SERVERS");
+    });
+
+    it("should classify server not found", () => {
+      const error = classifyAttestationError("Server not found in presentation", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.VERIFICATION);
+      expect(error.suggestion).toContain("banking API");
+    });
+
+    it("should classify invalid payment data", () => {
+      const error = classifyAttestationError("Invalid payment data: amount mismatch", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.VERIFICATION);
+      expect(error.suggestion).toContain("amount and IBAN");
+    });
+  });
+
+  describe("signing errors", () => {
+    it("should classify signing errors", () => {
+      const error = classifyAttestationError("Signing error: key not found", 500, "0x123");
+      expect(error.stage).toBe(AttestationStage.SIGNING);
+      expect(error.suggestion).toContain("witness private key");
+    });
+
+    it("should classify NotAuthorizedWitness", () => {
+      const error = classifyAttestationError("Error 0x41110897: NotAuthorizedWitness", 500, "0x123");
+      expect(error.stage).toBe(AttestationStage.SIGNING);
+      expect(error.suggestion).toContain("PaymentVerifier contract");
+    });
+  });
+
+  describe("fallback classification", () => {
+    it("should use 400 code to suggest proof submission", () => {
+      const error = classifyAttestationError("Unknown error XYZ", 400, "0x123");
+      expect(error.stage).toBe(AttestationStage.PROOF_SUBMISSION);
+      expect(error.httpCode).toBe(400);
+    });
+
+    it("should use 500 code to suggest signing", () => {
+      const error = classifyAttestationError("Unknown server error", 500, "0x123");
+      expect(error.stage).toBe(AttestationStage.SIGNING);
+      expect(error.httpCode).toBe(500);
+    });
+
+    it("should default to connection for unknown errors", () => {
+      const error = classifyAttestationError("Completely unknown", undefined, "0x123");
+      expect(error.stage).toBe(AttestationStage.CONNECTION);
+      expect(error.suggestion).toContain("logs");
+    });
+  });
+
+  it("should include intent hash in error", () => {
+    const error = classifyAttestationError("Some error", 400, "0xintentabc");
+    expect(error.intentHash).toBe("0xintentabc");
+  });
+});
+
+describe("createConnectionError", () => {
+  it("should wrap Error objects", () => {
+    const originalError = new Error("ECONNREFUSED");
+    const error = createConnectionError(originalError, "0x123");
+    expect(error.stage).toBe(AttestationStage.CONNECTION);
+    expect(error.originalError).toBe("ECONNREFUSED");
+    expect(error.intentHash).toBe("0x123");
+  });
+
+  it("should force CONNECTION stage for unrecognized errors", () => {
+    const originalError = new Error("Some weird network thing");
+    const error = createConnectionError(originalError, "0x123");
+    expect(error.stage).toBe(AttestationStage.CONNECTION);
+  });
+
+  it("should handle socket hang up", () => {
+    const originalError = new Error("socket hang up");
+    const error = createConnectionError(originalError, "0x123");
+    expect(error.stage).toBe(AttestationStage.CONNECTION);
+    expect(error.suggestion).toContain("crashed or restarted");
+  });
+});

--- a/solver/src/attestation/errors.ts
+++ b/solver/src/attestation/errors.ts
@@ -1,0 +1,232 @@
+/**
+ * Structured error types for attestation service
+ *
+ * Provides actionable error messages with stage information and suggestions
+ * to help operators quickly diagnose and fix attestation failures.
+ */
+
+/**
+ * Stages of the attestation process where errors can occur
+ */
+export enum AttestationStage {
+  /** Connecting to attestation service */
+  CONNECTION = "CONNECTION",
+  /** Submitting proof to service */
+  PROOF_SUBMISSION = "PROOF_SUBMISSION",
+  /** Verifying TLSNotary proof */
+  VERIFICATION = "VERIFICATION",
+  /** Signing EIP-712 attestation */
+  SIGNING = "SIGNING",
+}
+
+/**
+ * Enhanced error class for attestation failures
+ * Includes stage, original error, and actionable suggestions
+ */
+export class AttestationServiceError extends Error {
+  /** Stage of attestation where failure occurred */
+  public readonly stage: AttestationStage;
+  /** Original error message from service or network */
+  public readonly originalError: string;
+  /** Actionable suggestion for fixing the issue */
+  public readonly suggestion: string;
+  /** HTTP status code if available */
+  public readonly httpCode?: number;
+  /** Intent hash for correlation in logs */
+  public readonly intentHash?: string;
+
+  constructor(params: {
+    stage: AttestationStage;
+    originalError: string;
+    suggestion: string;
+    httpCode?: number;
+    intentHash?: string;
+  }) {
+    const message = `Attestation failed at ${params.stage}: ${params.originalError}. Suggestion: ${params.suggestion}`;
+    super(message);
+    this.name = "AttestationServiceError";
+    this.stage = params.stage;
+    this.originalError = params.originalError;
+    this.suggestion = params.suggestion;
+    this.httpCode = params.httpCode;
+    this.intentHash = params.intentHash;
+  }
+
+  /**
+   * Returns a structured object for logging
+   */
+  toLogContext(): Record<string, unknown> {
+    return {
+      errorType: this.name,
+      stage: this.stage,
+      originalError: this.originalError,
+      suggestion: this.suggestion,
+      httpCode: this.httpCode,
+      intentHash: this.intentHash,
+    };
+  }
+}
+
+/**
+ * Error patterns and their actionable suggestions
+ */
+const ERROR_SUGGESTIONS: Array<{
+  pattern: RegExp;
+  stage: AttestationStage;
+  suggestion: string;
+}> = [
+  // Connection errors
+  {
+    pattern: /ECONNREFUSED|connection refused/i,
+    stage: AttestationStage.CONNECTION,
+    suggestion: "Attestation service not running. Start with: docker compose up attestation-service",
+  },
+  {
+    pattern: /ENOTFOUND|getaddrinfo|DNS/i,
+    stage: AttestationStage.CONNECTION,
+    suggestion: "Cannot resolve attestation service hostname. Check ATTESTATION_SERVICE_URL in .env",
+  },
+  {
+    pattern: /ETIMEDOUT|timeout|aborted/i,
+    stage: AttestationStage.CONNECTION,
+    suggestion: "Request timed out. Check network connectivity and attestation service health",
+  },
+  {
+    pattern: /ECONNRESET|socket hang up/i,
+    stage: AttestationStage.CONNECTION,
+    suggestion: "Connection reset by server. Attestation service may have crashed or restarted",
+  },
+
+  // Proof submission errors (400 Bad Request)
+  {
+    pattern: /Invalid presentation/i,
+    stage: AttestationStage.PROOF_SUBMISSION,
+    suggestion: "TLSNotary proof format invalid. Regenerate proof with the TLSNotary prover",
+  },
+  {
+    pattern: /Deserialization error/i,
+    stage: AttestationStage.PROOF_SUBMISSION,
+    suggestion: "Proof data corrupted or malformed. Regenerate TLSNotary proof",
+  },
+  {
+    pattern: /Missing required field/i,
+    stage: AttestationStage.PROOF_SUBMISSION,
+    suggestion: "Proof missing required data fields. Ensure proof includes all payment details",
+  },
+
+  // Verification errors
+  {
+    pattern: /Verification failed/i,
+    stage: AttestationStage.VERIFICATION,
+    suggestion: "TLSNotary proof verification failed. Proof may be expired or tampered",
+  },
+  {
+    pattern: /Server not found|ServerNotFound/i,
+    stage: AttestationStage.VERIFICATION,
+    suggestion: "Server info not in proof. Ensure proof was captured from allowed banking API",
+  },
+  {
+    pattern: /Unexpected server/i,
+    stage: AttestationStage.VERIFICATION,
+    suggestion: "Proof server mismatch. Check ALLOWED_SERVERS config includes the bank API domain",
+  },
+  {
+    pattern: /Transcript not found|TranscriptNotFound/i,
+    stage: AttestationStage.VERIFICATION,
+    suggestion: "Proof missing transcript data. TLSNotary session may not have captured response",
+  },
+  {
+    pattern: /Invalid payment data/i,
+    stage: AttestationStage.VERIFICATION,
+    suggestion: "Payment details in proof don't match expected values. Verify amount and IBAN",
+  },
+
+  // Signing errors (500 Internal Server Error)
+  {
+    pattern: /Signing error/i,
+    stage: AttestationStage.SIGNING,
+    suggestion: "EIP-712 signing failed. Check witness private key configuration",
+  },
+  {
+    pattern: /0x41110897|NotAuthorizedWitness/i,
+    stage: AttestationStage.SIGNING,
+    suggestion: "Witness not authorized on-chain. Register witness address in PaymentVerifier contract",
+  },
+
+  // Generic errors
+  {
+    pattern: /Internal error/i,
+    stage: AttestationStage.SIGNING,
+    suggestion: "Internal attestation service error. Check service logs for details",
+  },
+];
+
+/**
+ * Maps raw error messages to structured AttestationServiceError
+ * Classifies error by stage and provides actionable suggestions
+ */
+export function classifyAttestationError(
+  rawError: string,
+  httpCode?: number,
+  intentHash?: string
+): AttestationServiceError {
+  // Match against known error patterns
+  for (const { pattern, stage, suggestion } of ERROR_SUGGESTIONS) {
+    if (pattern.test(rawError)) {
+      return new AttestationServiceError({
+        stage,
+        originalError: rawError,
+        suggestion,
+        httpCode,
+        intentHash,
+      });
+    }
+  }
+
+  // Fallback classification based on HTTP code
+  let stage = AttestationStage.CONNECTION;
+  let suggestion = "Unknown error. Check attestation service logs for details";
+
+  if (httpCode) {
+    if (httpCode === 400) {
+      stage = AttestationStage.PROOF_SUBMISSION;
+      suggestion = "Bad request. Check proof format and request payload";
+    } else if (httpCode >= 500) {
+      stage = AttestationStage.SIGNING;
+      suggestion = "Server error. Check attestation service logs";
+    }
+  }
+
+  return new AttestationServiceError({
+    stage,
+    originalError: rawError,
+    suggestion,
+    httpCode,
+    intentHash,
+  });
+}
+
+/**
+ * Creates a connection error for network-level failures
+ */
+export function createConnectionError(
+  error: Error,
+  intentHash?: string
+): AttestationServiceError {
+  const rawError = error.message || String(error);
+
+  // Check for known network error patterns
+  const classified = classifyAttestationError(rawError, undefined, intentHash);
+
+  // If not classified as connection, force it
+  if (classified.stage !== AttestationStage.CONNECTION) {
+    return new AttestationServiceError({
+      stage: AttestationStage.CONNECTION,
+      originalError: rawError,
+      suggestion: "Network error connecting to attestation service. Check service availability",
+      intentHash,
+    });
+  }
+
+  return classified;
+}

--- a/solver/src/attestation/index.ts
+++ b/solver/src/attestation/index.ts
@@ -1,4 +1,5 @@
 export * from "./client.js";
+export * from "./errors.js";
 export * from "./types.js";
 export * from "./prover.js";
 


### PR DESCRIPTION
## Summary
Implements structured error handling in the attestation client as specified in Issue #4. When attestation fails, errors now include:
- Which stage failed (CONNECTION, PROOF_SUBMISSION, VERIFICATION, SIGNING)
- The original error message from the service
- An actionable suggestion for fixing the issue
- Intent hash for log correlation

**Before:** `Attestation failed: Request failed`

**After:** `Attestation failed at VERIFICATION: Unexpected server: expected api.bank.com, got other.com. Suggestion: Proof server mismatch. Check ALLOWED_SERVERS config includes the bank API domain`

## Evidence
- Linked issue: #4 (Improve error messages in attestation client)
- File references:
  - `solver/src/attestation/client.ts:134` - Original generic error throw
  - `attestation-service/src/error.rs` - Error types from Rust service

## Dependencies
- Lockfile changes: NO
- Dependency changes: NONE

## Changes
- Created `solver/src/attestation/errors.ts` with:
  - `AttestationStage` enum (CONNECTION, PROOF_SUBMISSION, VERIFICATION, SIGNING)
  - `AttestationServiceError` class with stage, originalError, suggestion, httpCode, intentHash
  - `classifyAttestationError()` function to map raw errors to structured errors
  - `createConnectionError()` helper for network-level failures
  - Pattern matching for common error types (ECONNREFUSED, timeout, verification, signing, etc.)
- Updated `solver/src/attestation/client.ts`:
  - `healthCheck()` now throws structured errors with connection stage
  - `attest()` catches network errors and classifies API errors
  - Errors include intent hash for log correlation
- Added `solver/src/attestation/errors.test.ts` with 21 comprehensive tests

## Testing
- All 29 tests pass (`npm test`)
- Build succeeds (`npm run build`)
- Error patterns mapped from `attestation-service/src/error.rs`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)